### PR TITLE
Sysctl userns and rustup updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [v1.0.24](https://github.com/fboulnois/universal-debian/compare/v1.0.23...v1.0.24) - 2024-03-29
+
+### Added
+
+* Update rustup to 1.27.0
+* Remove automatic upgrade to Debian 12
+
+### Fixed
+
+* Kernel.unprivileged_userns_clone is deprecated
+
 ## [v1.0.23](https://github.com/fboulnois/universal-debian/compare/v1.0.22...v1.0.23) - 2023-12-26
 
 ### Added

--- a/install-debian.sh
+++ b/install-debian.sh
@@ -29,8 +29,8 @@ setup_git() {
 
 setup_rust() {
   cd "$HOME"
-  RUST_SHA256="be3535b3033ff5e0ecc4d589a35d3656f681332f860c5fd6684859970165ddcc"
-  curl -O https://raw.githubusercontent.com/rust-lang/rustup/1.26.0/rustup-init.sh
+  RUST_SHA256="7b826d2c84318cf44897da29225cb9bc0b4e859b05568b5979bf2cc264840d05"
+  curl -O https://raw.githubusercontent.com/rust-lang/rustup/1.27.0/rustup-init.sh
   echo "${RUST_SHA256}  rustup-init.sh" | sha256sum -c -
   chmod +x rustup-init.sh && ./rustup-init.sh -y && rm rustup-init.sh
   # shellcheck source=/dev/null

--- a/install-debian.sh
+++ b/install-debian.sh
@@ -142,7 +142,7 @@ install_docker() {
 
 setup_docker() {
   # disable unprivileged user namespaces
-  sudo sysctl -w kernel.unprivileged_userns_clone=0
+  sudo sysctl -w user.max_user_namespaces=0
   # install docker and enable buildkit
   install_docker
   echo '{ "features": { "buildkit": true } }' | sudo tee /etc/docker/daemon.json


### PR DESCRIPTION
* Switch from `kernel.unprivileged_userns_clone` which is deprecated to `user.max_user_namespaces` instead
* Update `rustup` to 1.27.0